### PR TITLE
Update Installation & Usage steps on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # EasyAVR-Tada68
-Added TADA68 support for [Easy AVR](https://github.com/dhowland/EasyAVR).
+TADA68/Saber68 support for [Easy AVR](https://github.com/dhowland/EasyAVR).
 
-# Instructions
-1. Download [EasyAVR](https://github.com/dhowland/EasyAVR), run it once and close it so that `~/.EasyAVR` is created (that's `C:\Users\[USERNAME]\.EasyAVR` for you windows users).
-2. Place `tada68.py` in `~/.EasyAVR/boards` and `tada68.cfg` in `~/.EasyAVR/configs`.
-3. Run EasyAVR again and select 'File' -> 'New Default Layout'. 
-4. Select Tada68, and be sure to choose ANSI or ISO in 'Available Layouts' dropdown.
-5. After editing your layout, select 'File'->'Build Firmware'. 
-6. Choose `\*.bin` as your 'Save as type', and save the file as `FLASH.BIN`. 
-7. Press the flash button on your TADA68, and replace the `FLASH.BIN` in the storage location, and press ESC.
+# Instructions (Windows)
+1. Download [EasyAVR](https://github.com/dhowland/EasyAVR), run it once and close it so that `~/.EasyAVR` is created (that's `C:\Users\[USERNAME]\.EasyAVR` for you Windows users).
+2. `git clone git@github.com:hillam/EasyAVR-Tada68.git`
+3. Navigate using File Explorer or `cli` to the `EasyAVR-Tada68` directory you've cloned from GitHub.
+4. Copy `tada68.py` in `~/.EasyAVR/boards` and `tada68.cfg` in `~/.EasyAVR/configs`.
+5. Run EasyAVR again and select 'File' -> 'New Layout'. 
+6. Select Tada68, and be sure to choose ANSI or ISO in 'Available Layouts' dropdown.
+7. After editing your layout, select 'File'->'Build Firmware'. 
+8. Choose `\*.bin` as your 'Save as type', and save the file as `FLASH.BIN`. 
+9. Press the flash button on your TADA68, and replace the `FLASH.BIN` in the storage location, and press ESC.
 
 
 ## TODO


### PR DESCRIPTION
* Update some steps that were missing or incorrectly labeled for Windows usage
* Will provide Mac instructions later once I confirm this works properly on Windows. My TADA68 is primarily used on my Windows/Linux machine.